### PR TITLE
Bump metro from 1.0.0 to 1.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ test-androidx-espresso = "3.7.0"
 
 navigation = "2.9.8"
 
-metro = "1.0.0"
+metro = "1.4.2"
 
 [plugins]
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "build-gradle-dependencyAnalysis" }


### PR DESCRIPTION
Updates the Metro DI compiler/runtime + Gradle plugin (dev.zacsweers.metro) from 1.0.0 to **1.4.2** (latest stable).

Verified locally on Gradle 9.7.1 / AGP 9.3.2: `:app:assembleDebug`, `:app:testDebugUnitTest`, and task enumeration all pass with no codegen or API breakage.

Part of a sweep bringing all dependencies to latest stable.