### PR TITLE
Align auto-mobile runner and CLI at 0.0.60 (fix AutoMobile CI)

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -294,7 +294,11 @@ jobs:
 
       - name: "Install auto-mobile"
         shell: "bash"
-        run: npm install -g @kaeawc/auto-mobile --ignore-scripts
+        # Pin to match auto-mobile-junit-runner in gradle/libs.versions.toml.
+        # The daemon/CLI and the runner must be the same version: a mismatch makes
+        # the daemon disable the executePlan tool (version-compatibility gate) and
+        # every AutoMobile plan fails. Bump both together.
+        run: npm install -g @kaeawc/auto-mobile@0.0.60 --ignore-scripts
 
       - name: "Copy auto-mobile schema to workspace"
         shell: "bash"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ androidx-activity-compose = "1.13.0"
 androidx-compose-bom = "2026.04.01"
 androidx-lifecycle = "2.10.0"
 
-auto-mobile-junit-runner = "0.0.30"
+auto-mobile-junit-runner = "0.0.60"
 
 test-junit = "4.13.2"
 test-androidx-junit = "1.3.0"


### PR DESCRIPTION
## Problem

The **AutoMobile JUnit Tests** / **AutoMobile Test Report** checks fail on every run of `main` (`AppLaunchAutoMobileTest`, `AppLifecycleAutoMobileTest` → `java.lang.AssertionError`, `result.success == false`).

Root cause is a **version mismatch** between the two halves of auto-mobile:

| Component | Where | Version |
|---|---|---|
| `auto-mobile-junit-runner` | `gradle/libs.versions.toml` | 0.0.30 (pinned) |
| `@kaeawc/auto-mobile` CLI/daemon | `.github/workflows/commit.yml` | **unpinned → 0.0.66** (npm `latest`) |

On connect the daemon runs a version-compatibility check and **disables the `executePlan` tool** for the session, so every plan returns `success=false`.

## Evidence (isolated local repro, API 34 emulator)

Reproduced in a clean, single-version daemon with a fresh DB and CtrlProxy installed via `observe` (matching CI setup):

- runner **0.0.30** + daemon **0.0.66** → daemon log: `Tool executePlan is disabled for device session … verifying version compatibility` → **FAIL** (reproduces CI)
- runner **0.0.60** + daemon **0.0.60** → `executePlan` enabled → **AppLaunch PASS ✅, AppLifecycle PASS ✅**

The app itself launches fine manually — this was never an app or dependency-bump problem.

## Fix

- Bump `auto-mobile-junit-runner` 0.0.30 → **0.0.60** (newest release on Maven Central for the runner).
- Pin the CLI to `@kaeawc/auto-mobile@0.0.60` so it stays in lockstep with the runner instead of drifting to `latest`.

Keep the two versions bumped together in future.