### PR TITLE
Bump asm, compose-bom, lifecycle, navigation to latest stable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ build-kotlin = "2.3.21"
 build-kotlin-language = "2.3"
 build-kotlin-coroutines = "1.11.0"
 build-kotlin-datetime = "0.8.0"
-build-java-asm = "9.9.1"
+build-java-asm = "9.10.1"
 build-java-target = "21"
 build-gradle-dependencyAnalysis = "3.19.1"
 build-gradle-graphAssertion = "2.9.1"
@@ -20,8 +20,8 @@ build-gradle-sortDependencies = "0.18.0"
 build-gradle-triplet-play = "4.1.1"
 androidx-core = "1.19.0"
 androidx-activity-compose = "1.13.0"
-androidx-compose-bom = "2026.04.01"
-androidx-lifecycle = "2.10.0"
+androidx-compose-bom = "2026.08.00"
+androidx-lifecycle = "2.11.0"
 
 auto-mobile-junit-runner = "0.0.30"
 
@@ -29,7 +29,7 @@ test-junit = "4.13.2"
 test-androidx-junit = "1.3.0"
 test-androidx-espresso = "3.7.0"
 
-navigation = "2.9.8"
+navigation = "2.10.0"
 
 metro = "1.4.2"
 


### PR DESCRIPTION
Batched low-risk dependency bumps to latest stable:

- org.ow2.asm: 9.9.1 → 9.10.1
- androidx.compose:compose-bom: 2026.04.01 → 2026.08.00
- androidx.lifecycle: 2.10.0 → 2.11.0
- androidx.navigation: 2.9.8 → 2.10.0

Verified locally on Gradle 9.7.1 / AGP 9.3.2: `:app:assembleDebug` and `:app:testDebugUnitTest` pass.

Part of the sweep bringing all dependencies to latest stable.