### PR TITLE
Bump Kotlin from 2.3.21 to 2.4.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ build-android-agp = "9.3.2"
 # Uncomment to pin R8 version (e.g. for dev versions needed for kotlin metadata)
 # build-android-r8 = "9.0.32"
 build-android-desugar = "2.1.5"
-build-kotlin = "2.3.21"
+build-kotlin = "2.4.10"
 build-kotlin-language = "2.3"
 build-kotlin-coroutines = "1.11.0"
 build-kotlin-datetime = "0.8.0"


### PR DESCRIPTION
Updates Kotlin to **2.4.10** (latest stable). Drives the Kotlin Gradle plugin, `org.jetbrains.kotlin.plugin.compose` (Compose compiler), stdlib, and KGP. `build-kotlin-language` stays pinned at 2.3.

Verified locally on Gradle 9.7.1 / AGP 9.3.2: `:app:assembleDebug` and `:app:testDebugUnitTest` pass — no compiler-plugin incompatibility from Metro 1.4.2 or the Compose compiler (the main risk with a Kotlin compiler bump).

Final item in the sweep bringing all dependencies to latest stable.