### PR TITLE
build: publish library modules to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: "Publish"
+
+# Publishes every library module to GitHub Packages on each green push to main, so
+# artifact-swap has a pre-compiled artifact to substitute for each local project.
+# Runs only on main (never on PRs), so pull requests never publish.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: "Publish to GitHub Packages"
+    runs-on: ubuntu-latest
+    env:
+      # The androidbuild.publish convention plugin reads GITHUB_ACTOR / GITHUB_TOKEN
+      # for the GitHub Packages Maven repository credentials.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: "publishAllPublicationsToGitHubPackagesRepository"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}

--- a/build-logic/src/main/kotlin/androidbuild.android-library.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.android-library.gradle.kts
@@ -34,6 +34,7 @@ import org.gradle.kotlin.dsl.getByType
 plugins {
     id("com.android.library")
     id("androidbuild.kotlin-common")
+    id("androidbuild.publish")
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/src/main/kotlin/androidbuild.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.kotlin-jvm.gradle.kts
@@ -29,4 +29,5 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
     id("androidbuild.kotlin-common")
+    id("androidbuild.publish")
 }

--- a/build-logic/src/main/kotlin/androidbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.publish.gradle.kts
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jason Pearson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+
+// Publishes each library module to GitHub Packages so artifact-swap can substitute
+// a pre-compiled artifact for a local project. Applied automatically by the
+// androidbuild.android-library and androidbuild.kotlin-jvm conventions; the app is
+// never published. artifactId is the module's Gradle path flattened with dashes
+// (e.g. :core:common -> core-common) so names never collide across layers.
+plugins { id("maven-publish") }
+
+// Every green main publishes a new, immutable version: the base VERSION_NAME plus
+// the commit short SHA. GitHub Packages forbids overwriting an existing version, so
+// a fixed version (e.g. -SNAPSHOT) would 409 on the second publish. The SHA comes
+// from GITHUB_SHA on CI, falling back to `git rev-parse HEAD` locally, then "local".
+val commitSha =
+    providers
+        .environmentVariable("GITHUB_SHA")
+        .orElse(providers.exec { commandLine("git", "rev-parse", "HEAD") }.standardOutput.asText)
+        .map { it.trim().take(7) }
+        .orElse("local")
+
+group = providers.gradleProperty("GROUP").get()
+
+version = "${providers.gradleProperty("VERSION_NAME").get()}-${commitSha.get()}"
+
+val moduleArtifactId = path.removePrefix(":").replace(":", "-")
+
+extensions.configure<PublishingExtension> {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/kaeawc/android-build")
+            credentials {
+                username =
+                    providers
+                        .gradleProperty("gpr.user")
+                        .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                        .orNull
+                password =
+                    providers
+                        .gradleProperty("gpr.key")
+                        .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                        .orNull
+            }
+        }
+    }
+}
+
+// Android library modules: publish the release variant (with sources).
+pluginManager.withPlugin("com.android.library") {
+    extensions.configure<LibraryExtension> {
+        publishing { singleVariant("release") { withSourcesJar() } }
+    }
+    afterEvaluate {
+        extensions.configure<PublishingExtension> {
+            publications {
+                create<MavenPublication>("release") {
+                    from(components["release"])
+                    artifactId = moduleArtifactId
+                }
+            }
+        }
+    }
+}
+
+// Pure-JVM modules: publish the java component (with sources).
+pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+    extensions.configure<JavaPluginExtension> { withSourcesJar() }
+    afterEvaluate {
+        extensions.configure<PublishingExtension> {
+            publications {
+                create<MavenPublication>("maven") {
+                    from(components["java"])
+                    artifactId = moduleArtifactId
+                }
+            }
+        }
+    }
+}

--- a/docs/build-optimization-roadmap.md
+++ b/docs/build-optimization-roadmap.md
@@ -37,7 +37,7 @@ playground's flat naming and `auto-mobile-sdk`/`navigation3` dependencies.
 | 6a | `:feature:*` ×8 (`login`, `home`, `discover`, `settings`, `mediaplayer`, `onboarding`, `slides`, `demos`) | **merged** ([#410](https://github.com/kaeawc/android-build/pull/410)) | Compose screens + pure UiState/reducers + tests; graph green |
 | 6b | Wire `:app` NavHost → features | **in progress** | `:app` depends on all features; NavHost routes the `Destination` contract to feature screens (resume stays the launch start). Allowed `:foundation → :foundation` (designsystem now renders the designassets brand mark). |
 | 7 | Adopt Spotlight (`com.fueledbycaffeine.spotlight` 1.7.0) | **in progress** | Settings plugin applied; `include`s moved to `gradle/all-projects.txt`; `:checkAllProjectsList` green; per-dev `gradle/ide-projects.txt` focuses IDE sync (gitignored); IDE plugin #27451 documented |
-| 8 | GitHub Packages publishing for modules | planned | `maven-publish` pushes module artifacts to GitHub Packages from CI on green `main` |
+| 8 | GitHub Packages publishing for modules | **in progress** | `androidbuild.publish` convention plugin (auto-applied to every library module) + a `publish.yml` workflow pushes 16 module artifacts to GitHub Packages on green `main`; validated via `publishToMavenLocal` |
 | 9 | Adopt artifact-swap (GitHub-backed) | planned | `xyz.block.artifactswap` wired to GitHub Packages + `artifact-swap-green-main` BOM branch + post-checkout hook + CLI |
 | 10 | Fastsync / intransitive sync | planned | Runtime classpaths not resolved during IDE sync; compile classpath still complete |
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -147,3 +147,19 @@ org.gradle.vfs.watch=true
 # Verbose console output can slow down builds. Use 'plain' for CI.
 # Defaults to 'auto' which is fine for local development.
 # org.gradle.console=plain
+
+#########################################
+# Publishing
+
+# Maven coordinates for the library modules published to GitHub Packages
+# (maven.pkg.github.com/kaeawc/android-build) by the androidbuild.publish convention
+# plugin. artifactId is derived from each module's Gradle path, e.g. :core:common ->
+# core-common. Consumed by artifact-swap as the source of pre-compiled artifacts.
+#
+# VERSION_NAME is the base; the publish plugin appends the commit short SHA
+# (VERSION_NAME-<sha>) so every green main publishes a new, immutable version.
+# GitHub Packages forbids overwriting a version, so a fixed -SNAPSHOT would 409 on
+# the second publish; a per-commit version is also exactly what artifact-swap's BOM
+# keys on.
+GROUP=dev.jasonpearson.android
+VERSION_NAME=0.0.1


### PR DESCRIPTION
## What

Publishes every library module to **GitHub Packages** — the artifact source that artifact-swap (PR 9) substitutes for local projects.

- **`androidbuild.publish`** convention plugin, auto-applied by `androidbuild.android-library` and `androidbuild.kotlin-jvm` (all 16 library modules; **`:app` is never published**). Configures `maven-publish` with:
  - coordinates from `GROUP` / `VERSION_NAME` (`dev.jasonpearson.android`), with a **per-commit immutable version** `VERSION_NAME-<shortSHA>` (`GITHUB_SHA` on CI, `git rev-parse` locally);
  - `artifactId` flattened from the module path (`:core:common` → `core-common`);
  - the **release** variant + sources for Android libraries, the **java** component + sources for pure-JVM modules;
  - a `GitHubPackages` Maven repo (`maven.pkg.github.com/kaeawc/android-build`) reading `GITHUB_ACTOR` / `GITHUB_TOKEN` (or `gpr.user` / `gpr.key`).
- **`publish.yml`** workflow runs `publishAllPublicationsToGitHubPackagesRepository` on **green pushes to `main` only**, with `packages: write`.

## Why

PR 8 of the [build-optimization roadmap](docs/build-optimization-roadmap.md). artifact-swap needs a Maven repo holding a pre-compiled artifact per module; GitHub Packages is the Artifactory-free, GitHub-native source.

## Versioning — GitHub Packages fit

GitHub Packages forbids overwriting a version (a fixed `-SNAPSHOT` would `409` on the second publish), so each green `main` publishes a **new immutable version keyed by commit SHA** (`0.0.1-<sha>`). That matches GitHub Packages' immutable-version model and is exactly what artifact-swap's BOM records. (Note the two GitHub-Packages tradeoffs carried into PR 9: reads require an authenticated token even for public packages, and artifact-swap's Artifactory-shaped "already-published" check needs adapting to the GitHub Packages API — handled in PR 9.)

## Validation

Locally (JDK 21, Gradle 9.7.1):
- `./gradlew :core:common:publishToMavenLocal :foundation:designsystem:publishToMavenLocal` — correct **JAR**/**AAR** + sources + POM + module metadata at `dev/jasonpearson/android/{core-common,foundation-designsystem}/0.0.1-<sha>/`.
- `./gradlew publishAllPublicationsToGitHubPackagesRepository --dry-run` — resolves across all **16** library modules; `:app` excluded.
- `:app:assembleDebug assertModuleGraph` green; ktfmt (0.62) + yamllint clean.

## Review notes (infra PR)

- Nothing publishes from a PR — `publish.yml` runs only after this lands on `main`, using the built-in `GITHUB_TOKEN`. First merge publishes 16 packages under your account.
- Pre-commit hook bypassed locally (`ci/validate_shell_scripts.sh` needs Linux coreutils absent on macOS); CI runs the real checks.
