### PR TITLE
chore: correct copyright year to 2026 in files created this year

### DIFF
--- a/app/src/main/java/dev/jasonpearson/android/navigation/FeatureNavGraph.kt
+++ b/app/src/main/java/dev/jasonpearson/android/navigation/FeatureNavGraph.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/src/main/kotlin/androidbuild.android-compose.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.android-compose.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/src/main/kotlin/androidbuild.android-library.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.android-library.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/src/main/kotlin/androidbuild.kotlin-common.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.kotlin-common.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/src/main/kotlin/androidbuild.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.kotlin-jvm.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/src/main/kotlin/androidbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/androidbuild.publish.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/DispatcherProvider.kt
+++ b/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/DispatcherProvider.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/Identifiable.kt
+++ b/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/Identifiable.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/SuspendCatching.kt
+++ b/core/common/src/main/kotlin/dev/jasonpearson/android/core/common/SuspendCatching.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/common/src/test/kotlin/dev/jasonpearson/android/core/common/SuspendCatchingTest.kt
+++ b/core/common/src/test/kotlin/dev/jasonpearson/android/core/common/SuspendCatchingTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/model/src/main/kotlin/dev/jasonpearson/android/core/model/MediaItem.kt
+++ b/core/model/src/main/kotlin/dev/jasonpearson/android/core/model/MediaItem.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/model/src/test/kotlin/dev/jasonpearson/android/core/model/MediaItemTest.kt
+++ b/core/model/src/test/kotlin/dev/jasonpearson/android/core/model/MediaItemTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/demos/build.gradle.kts
+++ b/feature/demos/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/demos/src/main/kotlin/dev/jasonpearson/android/feature/demos/DemosScreen.kt
+++ b/feature/demos/src/main/kotlin/dev/jasonpearson/android/feature/demos/DemosScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/demos/src/main/kotlin/dev/jasonpearson/android/feature/demos/DemosUiState.kt
+++ b/feature/demos/src/main/kotlin/dev/jasonpearson/android/feature/demos/DemosUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/demos/src/test/kotlin/dev/jasonpearson/android/feature/demos/DemosUiStateTest.kt
+++ b/feature/demos/src/test/kotlin/dev/jasonpearson/android/feature/demos/DemosUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/discover/build.gradle.kts
+++ b/feature/discover/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/discover/src/main/kotlin/dev/jasonpearson/android/feature/discover/DiscoverScreen.kt
+++ b/feature/discover/src/main/kotlin/dev/jasonpearson/android/feature/discover/DiscoverScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/discover/src/main/kotlin/dev/jasonpearson/android/feature/discover/DiscoverUiState.kt
+++ b/feature/discover/src/main/kotlin/dev/jasonpearson/android/feature/discover/DiscoverUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/discover/src/test/kotlin/dev/jasonpearson/android/feature/discover/DiscoverUiStateTest.kt
+++ b/feature/discover/src/test/kotlin/dev/jasonpearson/android/feature/discover/DiscoverUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/home/src/main/kotlin/dev/jasonpearson/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/dev/jasonpearson/android/feature/home/HomeScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/home/src/main/kotlin/dev/jasonpearson/android/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/kotlin/dev/jasonpearson/android/feature/home/HomeUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/home/src/test/kotlin/dev/jasonpearson/android/feature/home/HomeUiStateTest.kt
+++ b/feature/home/src/test/kotlin/dev/jasonpearson/android/feature/home/HomeUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/login/src/main/kotlin/dev/jasonpearson/android/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/kotlin/dev/jasonpearson/android/feature/login/LoginScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/login/src/main/kotlin/dev/jasonpearson/android/feature/login/LoginUiState.kt
+++ b/feature/login/src/main/kotlin/dev/jasonpearson/android/feature/login/LoginUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/login/src/test/kotlin/dev/jasonpearson/android/feature/login/LoginUiStateTest.kt
+++ b/feature/login/src/test/kotlin/dev/jasonpearson/android/feature/login/LoginUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/mediaplayer/build.gradle.kts
+++ b/feature/mediaplayer/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/mediaplayer/src/main/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerScreen.kt
+++ b/feature/mediaplayer/src/main/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/mediaplayer/src/main/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerUiState.kt
+++ b/feature/mediaplayer/src/main/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/mediaplayer/src/test/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerUiStateTest.kt
+++ b/feature/mediaplayer/src/test/kotlin/dev/jasonpearson/android/feature/mediaplayer/MediaPlayerUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/onboarding/src/main/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/onboarding/src/main/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingUiState.kt
+++ b/feature/onboarding/src/main/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/onboarding/src/test/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingUiStateTest.kt
+++ b/feature/onboarding/src/test/kotlin/dev/jasonpearson/android/feature/onboarding/OnboardingUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/settings/src/main/kotlin/dev/jasonpearson/android/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/dev/jasonpearson/android/feature/settings/SettingsScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/settings/src/main/kotlin/dev/jasonpearson/android/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/dev/jasonpearson/android/feature/settings/SettingsUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/settings/src/test/kotlin/dev/jasonpearson/android/feature/settings/SettingsUiStateTest.kt
+++ b/feature/settings/src/test/kotlin/dev/jasonpearson/android/feature/settings/SettingsUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/slides/build.gradle.kts
+++ b/feature/slides/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/slides/src/main/kotlin/dev/jasonpearson/android/feature/slides/SlidesScreen.kt
+++ b/feature/slides/src/main/kotlin/dev/jasonpearson/android/feature/slides/SlidesScreen.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/slides/src/main/kotlin/dev/jasonpearson/android/feature/slides/SlidesUiState.kt
+++ b/feature/slides/src/main/kotlin/dev/jasonpearson/android/feature/slides/SlidesUiState.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/feature/slides/src/test/kotlin/dev/jasonpearson/android/feature/slides/SlidesUiStateTest.kt
+++ b/feature/slides/src/test/kotlin/dev/jasonpearson/android/feature/slides/SlidesUiStateTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designassets/build.gradle.kts
+++ b/foundation/designassets/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designassets/src/main/res/drawable/ic_brand_mark.xml
+++ b/foundation/designassets/src/main/res/drawable/ic_brand_mark.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2024 Jason Pearson
+  ~ Copyright (c) 2026 Jason Pearson
   -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="48dp"

--- a/foundation/designsystem/build.gradle.kts
+++ b/foundation/designsystem/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/components/BrandLogo.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/components/BrandLogo.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/components/Buttons.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/components/Buttons.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Color.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Color.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Shapes.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Shapes.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Theme.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Theme.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Typography.kt
+++ b/foundation/designsystem/src/main/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/Typography.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/designsystem/src/test/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/ColorContrastTest.kt
+++ b/foundation/designsystem/src/test/kotlin/dev/jasonpearson/android/foundation/designsystem/theme/ColorContrastTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/navigation/build.gradle.kts
+++ b/foundation/navigation/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/navigation/src/main/kotlin/dev/jasonpearson/android/foundation/navigation/Destination.kt
+++ b/foundation/navigation/src/main/kotlin/dev/jasonpearson/android/foundation/navigation/Destination.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/navigation/src/main/kotlin/dev/jasonpearson/android/foundation/navigation/NavigationExtensions.kt
+++ b/foundation/navigation/src/main/kotlin/dev/jasonpearson/android/foundation/navigation/NavigationExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/foundation/navigation/src/test/kotlin/dev/jasonpearson/android/foundation/navigation/DestinationTest.kt
+++ b/foundation/navigation/src/test/kotlin/dev/jasonpearson/android/foundation/navigation/DestinationTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/analytics/build.gradle.kts
+++ b/subsystem/analytics/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/analytics/src/main/kotlin/dev/jasonpearson/android/subsystem/analytics/AnalyticsClient.kt
+++ b/subsystem/analytics/src/main/kotlin/dev/jasonpearson/android/subsystem/analytics/AnalyticsClient.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/analytics/src/main/kotlin/dev/jasonpearson/android/subsystem/analytics/RecordingAnalyticsClient.kt
+++ b/subsystem/analytics/src/main/kotlin/dev/jasonpearson/android/subsystem/analytics/RecordingAnalyticsClient.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/analytics/src/test/kotlin/dev/jasonpearson/android/subsystem/analytics/RecordingAnalyticsClientTest.kt
+++ b/subsystem/analytics/src/test/kotlin/dev/jasonpearson/android/subsystem/analytics/RecordingAnalyticsClientTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/experimentation/build.gradle.kts
+++ b/subsystem/experimentation/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/experimentation/src/main/kotlin/dev/jasonpearson/android/subsystem/experimentation/Experiment.kt
+++ b/subsystem/experimentation/src/main/kotlin/dev/jasonpearson/android/subsystem/experimentation/Experiment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/experimentation/src/main/kotlin/dev/jasonpearson/android/subsystem/experimentation/ExperimentRepository.kt
+++ b/subsystem/experimentation/src/main/kotlin/dev/jasonpearson/android/subsystem/experimentation/ExperimentRepository.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/experimentation/src/test/kotlin/dev/jasonpearson/android/subsystem/experimentation/ExperimentRepositoryTest.kt
+++ b/subsystem/experimentation/src/test/kotlin/dev/jasonpearson/android/subsystem/experimentation/ExperimentRepositoryTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/storage/build.gradle.kts
+++ b/subsystem/storage/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/KeyValueStore.kt
+++ b/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/KeyValueStore.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/SessionRepository.kt
+++ b/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/SessionRepository.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/UserPreferencesRepository.kt
+++ b/subsystem/storage/src/main/kotlin/dev/jasonpearson/android/subsystem/storage/UserPreferencesRepository.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/subsystem/storage/src/test/kotlin/dev/jasonpearson/android/subsystem/storage/SessionRepositoryTest.kt
+++ b/subsystem/storage/src/test/kotlin/dev/jasonpearson/android/subsystem/storage/SessionRepositoryTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 Jason Pearson
+ * Copyright (c) 2026 Jason Pearson
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Header-only: the 75 files created by the modularization program (PRs #406–#411, #413) carried a `Copyright (c) 2024` header copied from pre-existing files; they were created in 2026. No code changes. (PR #415's new file gets the same fix on its own branch.)