### PR TITLE
fix: disable config cache + Isolated Projects for CLI task-finder/task-runner

### DIFF
--- a/scripts/artifact-swap/ci-publish.sh
+++ b/scripts/artifact-swap/ci-publish.sh
@@ -43,10 +43,17 @@ echo "===== Finding publish tasks ====="
 # Note: no -Partifactswap.publishingEnabled=true here. This repo applies the Artifact
 # Swap publish plugin through the androidbuild.publish convention (gated on the
 # version-file property) instead of the settings-plugin auto-apply.
+# --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false: task-finder
+# realizes every project's tasks via the Tooling API, and the module-graph assertion
+# plugin's task registration reaches across projects, which Isolated Projects forbids.
+# Mirrors the repo's own whole-graph CI jobs (gradle-task-run with
+# reuse-configuration-cache: false). Real builds keep IP on.
 "$bin_path" task-finder \
   --dir "$git_root" \
   --logging INFO \
   --gradle-args "-Partifactswap.artifactVersionFile=$hash_file" \
+  --gradle-args "--no-configuration-cache" \
+  --gradle-args "-Dorg.gradle.unsafe.isolated-projects=false" \
   --task-list-output-directory "taskOutputs" \
   --task publishToArtifactSwapRepository \
   --log-gradle \
@@ -65,6 +72,8 @@ echo "===== Publishing missing artifacts ====="
   --dir "$git_root" \
   --logging INFO \
   --gradle-args "-Partifactswap.artifactVersionFile=$hash_file" \
+  --gradle-args "--no-configuration-cache" \
+  --gradle-args "-Dorg.gradle.unsafe.isolated-projects=false" \
   --task-list-file "taskOutputs/task-output-filtered.out" \
   --log-gradle
 


### PR DESCRIPTION
First gated Publish run on `1dd0d03` failed at **task-finder** with `Project ':app' cannot access 'Project.hasProperty' functionality on subprojects` — the Tooling-API task realization trips the module-graph plugin's cross-project access under Isolated Projects (the exact conflict the repo's own whole-graph CI jobs already work around via `reuse-configuration-cache: false` → `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false`). Applies the same flags to the CLI's task-finder and task-runner invocations. hashing passed with IP on and is untouched; real builds keep IP on. The merge of this PR re-triggers the gated Publish run, self-testing the fix (next unknowns in line: artifact-checker auth, bom-publisher upload).