### PR TITLE
fix: use GitHub-Packages-compatible patched Artifact Swap CLI

### DIFF
--- a/docs/artifact-swap.md
+++ b/docs/artifact-swap.md
@@ -103,6 +103,10 @@ set in gradle.properties; removing it would silently publish unauthenticated and
 - `artifactswap.enabled` defaults to **false** because an enabled sync with no BOM in Maven Local
   fails module selection ("found no matching BOMs"). Enable it after the first
   `download-artifacts.sh` run.
+- The CLI is a patched build of upstream v0.1.12 (GitHub Packages requires authentication on
+  every request, and its generated maven-metadata.xml omits `<release>`); see
+  [patches/artifact-swap/](../patches/artifact-swap/) for the diff and rebuild instructions. The
+  Gradle plugins are stock.
 - Artifact Swap's settings plugin requires the Develocity plugin on the settings classpath (it
   references the build-scan API); it's applied without a server, so no scans are published.
 - The CLI's telemetry endpoint is pointed at a fast-failing localhost port; the resulting log

--- a/patches/artifact-swap/README.md
+++ b/patches/artifact-swap/README.md
@@ -1,0 +1,20 @@
+# Artifact Swap CLI patches
+
+The CLI in use is a patched build of [block/artifact-swap](https://github.com/block/artifact-swap)
+v0.1.12, published as a release asset on this repo
+(`cli-<version>` tags) and downloaded by `scripts/artifact-swap/install-cli.sh`.
+
+`artifactswap-cli-0.1.12-kaeawc.1.patch` — two GitHub Packages compatibility fixes,
+both candidates for upstream contribution:
+
+1. **NetworkModule**: upstream skips the Authorization header on GET/HEAD (valid for
+   Artifactory instances with anonymous reads); GitHub Packages requires authentication
+   on every request, so the header (Basic, `token:<token>`) is now always attached.
+   Empirically verified: unauthenticated reads 401; Basic/Bearer/token schemes all 200.
+2. **maven `Metadata` model**: `<release>` made nullable — GitHub Packages' generated
+   `maven-metadata.xml` omits the element that Artifactory includes, which made every
+   metadata parse fail (`KotlinInvalidNullException`).
+
+To rebuild: clone upstream at `v0.1.12`, apply the patch, set `version` in
+`gradle.properties`, run `./gradlew :cli:distZip`, and attach
+`cli/build/distributions/artifactswap-<version>.zip` to a `cli-<version>` release.

--- a/patches/artifact-swap/artifactswap-cli-0.1.12-kaeawc.1.patch
+++ b/patches/artifact-swap/artifactswap-cli-0.1.12-kaeawc.1.patch
@@ -1,0 +1,69 @@
+diff --git a/cli/src/main/kotlin/xyz/block/artifactswap/cli/di/NetworkModule.kt b/cli/src/main/kotlin/xyz/block/artifactswap/cli/di/NetworkModule.kt
+index 4e6f1e9..37e9b48 100644
+--- a/cli/src/main/kotlin/xyz/block/artifactswap/cli/di/NetworkModule.kt
++++ b/cli/src/main/kotlin/xyz/block/artifactswap/cli/di/NetworkModule.kt
+@@ -31,7 +31,6 @@ import xyz.block.artifactswap.core.eventstream.EventstreamService
+ import xyz.block.artifactswap.core.network.ArtifactoryEndpoints
+ import xyz.block.artifactswap.core.network.ArtifactoryService
+ 
+-private val UNAUTHENTICATED_HTTP_METHODS = listOf("GET", "HEAD")
+ private const val MAX_RETRY_ATTEMPTS = 5
+ 
+ internal fun artifactoryNetworkModule() = module {
+@@ -110,17 +109,20 @@ internal fun artifactoryNetworkModule() = module {
+       }
+       .addNetworkInterceptor(get<Interceptor>(named("cache404Interceptor")))
+       .addInterceptor { chain ->
+-        // GET/HEAD methods don't require authentication
+-        if (chain.request().method !in UNAUTHENTICATED_HTTP_METHODS) {
+-          val newRequest =
+-            chain
+-              .request()
+-              .newBuilder()
+-              .addHeader("Authorization", "Bearer ${get<String>(named("artifactoryToken"))}")
+-              .build()
+-          return@addInterceptor chain.proceed(newRequest)
+-        }
+-        return@addInterceptor chain.proceed(chain.request())
++        // kaeawc patch for GitHub Packages: unlike Artifactory with anonymous reads,
++        // GitHub Packages requires authentication on EVERY request (including GET/HEAD),
++        // and accepts Basic (any username + token) rather than Bearer. Always attach
++        // Basic credentials.
++        val newRequest =
++          chain
++            .request()
++            .newBuilder()
++            .addHeader(
++              "Authorization",
++              okhttp3.Credentials.basic("token", get<String>(named("artifactoryToken"))),
++            )
++            .build()
++        return@addInterceptor chain.proceed(newRequest)
+       }
+       .build()
+   }
+diff --git a/core/src/main/kotlin/xyz/block/artifactswap/core/maven/Metadata.kt b/core/src/main/kotlin/xyz/block/artifactswap/core/maven/Metadata.kt
+index 572d188..18d6699 100644
+--- a/core/src/main/kotlin/xyz/block/artifactswap/core/maven/Metadata.kt
++++ b/core/src/main/kotlin/xyz/block/artifactswap/core/maven/Metadata.kt
+@@ -8,7 +8,9 @@ data class Metadata(val groupId: String, val artifactId: String, val versioning:
+ 
+ data class Versioning(
+   val latest: String,
+-  val release: String,
++  // kaeawc patch for GitHub Packages: its generated maven-metadata.xml omits the
++  // <release> element that Artifactory includes; nothing outside this model reads it.
++  val release: String? = null,
+   val versions: Versions,
+   val lastUpdated: Long,
+ )
+diff --git a/gradle.properties b/gradle.properties
+index 238ce55..fcffecc 100644
+--- a/gradle.properties
++++ b/gradle.properties
+@@ -11,4 +11,4 @@ org.gradle.configuration-cache.parallel=true
+ org.gradle.parallel=true
+ 
+ group=xyz.block.artifactswap
+-version=0.1.12
++version=0.1.12-kaeawc.1

--- a/scripts/artifact-swap/env.sh
+++ b/scripts/artifact-swap/env.sh
@@ -1,11 +1,12 @@
 # shellcheck shell=bash
 # Shared environment for the Artifact Swap scripts. Source, don't execute.
 #
-# Single source of truth for the CLI version on the shell side. Keep in lockstep
-# with `build-artifactswap` in gradle/libs.versions.toml and the
-# xyz.block.artifactswap.settings plugin version in settings.gradle.kts (Gradle
-# cannot read this file, so those two are declared separately).
-ARTIFACTSWAP_VERSION="0.1.12"
+# Single source of truth for the CLI version on the shell side. The CLI is a
+# patched build of upstream v0.1.12 (see patches/artifact-swap/), hosted as a
+# release asset on this repo; the Gradle plugins stay on stock 0.1.12
+# (`build-artifactswap` in gradle/libs.versions.toml and the settings plugin
+# version in settings.gradle.kts).
+ARTIFACTSWAP_VERSION="0.1.12-kaeawc.1"
 
 # Absolute path to the CLI binary for a given repo root.
 artifactswap_bin() {

--- a/scripts/artifact-swap/install-cli.sh
+++ b/scripts/artifact-swap/install-cli.sh
@@ -22,9 +22,12 @@ mkdir -p "$tools_dir"
 tmp_zip=$(mktemp -t artifactswap-cli.XXXXXX)
 trap 'rm -f "$tmp_zip"' EXIT
 
+# Patched build for GitHub Packages compatibility (always-authenticated Basic
+# requests; nullable <release> in maven metadata), hosted as a release asset on
+# this repo. See patches/artifact-swap/ for the exact diff vs upstream v0.1.12.
 echo "Downloading Artifact Swap CLI $ARTIFACTSWAP_VERSION..."
 curl -sL --fail --max-time 300 \
-  "https://repo.maven.apache.org/maven2/xyz/block/artifactswap/cli/$ARTIFACTSWAP_VERSION/cli-$ARTIFACTSWAP_VERSION.zip" \
+  "https://github.com/kaeawc/android-build/releases/download/cli-$ARTIFACTSWAP_VERSION/artifactswap-$ARTIFACTSWAP_VERSION.zip" \
   -o "$tmp_zip"
 unzip -q -o "$tmp_zip" -d "$tools_dir"
 chmod +x "$bin_path"


### PR DESCRIPTION
Fixes the Publish pipeline's bom-publisher failure (attempt 2: 17× 401 on metadata reads). Root causes, both verified locally against the live registry: upstream CLI sends **no auth header on GET/HEAD** (Artifactory-anonymous-reads assumption; GitHub Packages requires auth on every request), and its `Metadata` model requires `<release>`, which GitHub Packages' generated metadata omits. Ships a patched CLI build (`0.1.12-kaeawc.1`, [release asset](https://github.com/kaeawc/android-build/releases/tag/cli-0.1.12-kaeawc.1), diff + rebuild instructions in `patches/artifact-swap/`); `install-cli.sh` downloads it from the release. Gradle plugins stay stock. Local verification with the patched binary: `bom-publisher --dry-run` reads all 16 live artifacts and assembles the BOM; the real PUT reached `createPackageVersion` and was blocked only by the local token lacking `write:packages` — CI's `GITHUB_TOKEN` has it. Merging self-tests via gated Publish attempt 3. Both patches are upstream-able to block/artifact-swap.